### PR TITLE
fix(capacitor/firebase): add __unparsed__ property to run command opt…

### DIFF
--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -16,6 +16,7 @@ export default async function runExecutor(
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
     command: `npx cap ${cmd}`,
+    __unparsed__: [],
   };
 
   return await runCommands(runCommandsOptions, context);

--- a/packages/firebase/src/executors/firebase/executor.ts
+++ b/packages/firebase/src/executors/firebase/executor.ts
@@ -16,6 +16,7 @@ export default async function runExecutor(
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
     command: `firebase ${cmd}`,
+    __unparsed__: [],
   };
 
   return await runCommands(runCommandsOptions, context);


### PR DESCRIPTION
…ions

without this property, the executor fails with error message
'Cannot read properties of undefined (reading 'length')'

Resolves #633

# Description

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #
